### PR TITLE
fix: Loading spinner for dynamic tree

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -40,7 +40,7 @@
 						{ Id: 9, Name: 'Faculty 2', Type: 7, Parents: [6606, 10], IsActive: false },
 						{ Id: 6606, Name: 'Dev', Type: 1, Parents: [0], IsActive: false }
 					];
-					const isOrgUnitsTruncated = false;
+					const isOrgUnitsTruncated = true;
 
 					this._orgUnitTree = new Tree({
 						// add in any nodes from the most recent search; otherwise

--- a/demo/index.html
+++ b/demo/index.html
@@ -73,7 +73,7 @@
 						return await super.fetchRelevantChildren(id, bookmark);
 					}
 
-					// imitatate more children for node 9: Faculty 2
+					// imitate more children for node 9: Faculty 2
 					const results = { PagingInfo: { HasMoreItems: false, Bookmark: 'orgUnit-9' }, Items: [
 						{ Id: 20, Name: 'Department 3', Type: 2, Parents: [9], IsActive: false }
 					] };

--- a/demo/index.html
+++ b/demo/index.html
@@ -40,7 +40,7 @@
 						{ Id: 9, Name: 'Faculty 2', Type: 7, Parents: [6606, 10], IsActive: false },
 						{ Id: 6606, Name: 'Dev', Type: 1, Parents: [0], IsActive: false }
 					];
-					const isOrgUnitsTruncated = true;
+					const isOrgUnitsTruncated = false;
 
 					this._orgUnitTree = new Tree({
 						// add in any nodes from the most recent search; otherwise
@@ -89,6 +89,13 @@
 
 					// return result in 2 sec to show loading spinner
 					return await new Promise(resolve => setTimeout(() => resolve(results), 2000));
+				}
+
+				// the method called only when Tree.isDynamic === true
+				async orgUnitSearch(searchString, bookmark) {
+					console.log(`orgUnitSearch ${searchString}, ${bookmark}`);
+
+					return await super.orgUnitSearch(searchString, bookmark);
 				}
 			}
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,8 +12,9 @@
 			import { MobxLitElement } from '@adobe/lit-mobx';
 			import { OuFilterDataManager } from '../ou-filter';
 
+			const orgUnitChildrenCache = new Map();
 			function fetchCachedChildren() {
-				return new Map();
+				return orgUnitChildrenCache;
 			}
 
 			class DemoDataManager extends OuFilterDataManager {
@@ -39,7 +40,7 @@
 						{ Id: 9, Name: 'Faculty 2', Type: 7, Parents: [6606, 10], IsActive: false },
 						{ Id: 6606, Name: 'Dev', Type: 1, Parents: [0], IsActive: false }
 					];
-					const isOrgUnitsTruncated = false;
+					const isOrgUnitsTruncated = true;
 
 					this._orgUnitTree = new Tree({
 						// add in any nodes from the most recent search; otherwise
@@ -61,6 +62,33 @@
 
 				get orgUnitTree() {
 					return this._orgUnitTree;
+				}
+
+				// the method called only when Tree.isDynamic === true
+				async fetchRelevantChildren(id, bookmark) {
+					console.log(`fetchRelevantChildren ${id}, ${bookmark}`);
+
+					if (id !== 9 || bookmark === 'orgUnit-9') {
+						// returns no children responce
+						return await super.fetchRelevantChildren(id, bookmark);
+					}
+
+					// imitatate more children for node 9: Faculty 2
+					const results = { PagingInfo: { HasMoreItems: false, Bookmark: 'orgUnit-9' }, Items: [
+						{ Id: 20, Name: 'Department 3', Type: 2, Parents: [9], IsActive: false }
+					] };
+
+					// example of handling cache
+					if (!orgUnitChildrenCache.has(id)) {
+						orgUnitChildrenCache.set(id, results);
+					} else {
+						const cached = orgUnitChildrenCache.get(id);
+						cached.PagingInfo = results.PagingInfo;
+						cached.Items.push(...results.Items);
+					}
+
+					// return result in 2 sec to show loading spinner
+					return await new Promise(resolve => setTimeout(() => resolve(results), 2000));
 				}
 			}
 

--- a/ou-filter.js
+++ b/ou-filter.js
@@ -20,7 +20,7 @@ export class OuFilterDataManager {
 	}
 
 	/**
-	 * Returns org units for the provided search string
+	 * Returns org units for the provided search string. It's called only when Tree.isDynamic == true.
 	 * @param {string} searchString
 	 * @param {string} bookmark
 	 * @returns {Object} - { PagingInfo:{ HasMoreItems: boolean, Bookmark: string }, Items: OrgUnitNode[] }. Fields indices are defined in tree-filter.js

--- a/ou-filter.js
+++ b/ou-filter.js
@@ -9,25 +9,25 @@ import { Tree } from './tree-filter';
 export class OuFilterDataManager {
 
 	/**
-	 * Fetches children of specified org unit
+	 * Fetches children of specified org unit. It's called only when Tree.isDynamic == true.
 	 * @param {string} id - org unit id
 	 * @param {string} bookmark
-	 * @returns {Object} - { PagingInfo:{ HasMoreItems: boolean, Bookmark: string }, Items: [{Id: integer, Name: string, Type: integer, Parents: [integer, ...], IsActive: boolean}] }. Fields indices are defined in tree-filter.js
+	 * @returns {Object} - { PagingInfo: { HasMoreItems: boolean, Bookmark: string }, Items: OrgUnitNode[] }. Fields indices are defined in tree-filter.js
 	 */
 	// eslint-disable-next-line no-unused-vars
 	async fetchRelevantChildren(id, bookmark) {
-		return null;
+		return { PagingInfo: {}, Items: [] };
 	}
 
 	/**
 	 * Returns org units for the provided search string
 	 * @param {string} searchString
 	 * @param {string} bookmark
-	 * @returns {Object} - { PagingInfo:{ HasMoreItems: boolean, Bookmark: string }, Items: [{Id: integer, Name: string, Type: integer, Parents: [integer, ...], IsActive: boolean}] }. Fields indices are defined in tree-filter.js
+	 * @returns {Object} - { PagingInfo:{ HasMoreItems: boolean, Bookmark: string }, Items: OrgUnitNode[] }. Fields indices are defined in tree-filter.js
 	 */
 	// eslint-disable-next-line no-unused-vars
 	async orgUnitSearch(searchString, bookmark) {
-		return null;
+		return { PagingInfo: {}, Items: [] };
 	}
 
 	/**

--- a/tree-filter.js
+++ b/tree-filter.js
@@ -1,3 +1,4 @@
+import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 import './tree-selector.js';
 
 import 'array-flat-polyfill';
@@ -9,12 +10,22 @@ import { MobxLitElement } from '@adobe/lit-mobx';
 // node array indices
 export const COURSE_OFFERING = 3;
 
+/**
+ * An object that represents org unit node
+ * @typedef {Object} OrgUnitNode
+ * @property {number} Id
+ * @property {string} Name
+ * @property {number} Type
+ * @property {number[]} Parents - array of org unit ids
+ * @property {boolean} IsActive - optional, should be populated if accessed via Tree.isActive property
+*/
+
 export class Tree {
 	/**
 	 * Type to use as the .tree property of a d2l-labs-tree-filter. Mutator methods will
 	 * trigger re-rendering as needed. Call as new Tree({}) for a default empty tree.
 	 * NB: this is actually a DAG, not a tree. :)
-	 * @param {[][]} [nodes=[]] - Array of arrays, each with elements for each of the above constants
+	 * @param {OrgUnitNode[]} [nodes=[]] - Array of OrgUnitNode
 	 * @param {Number[]} [leafTypes=[]] - TYPE values that cannot be opened
 	 * @param {Number[]} [invisibleTypes=[]] - TYPE values that should not be rendered
 	 * @param {Number[]} [selectedIds] - ids to mark selected. Ancestors and descendants will be marked accordingly.
@@ -23,7 +34,7 @@ export class Tree {
 	 * @param {Boolean} isDynamic - if true, the tree is assumed to be incomplete, and tree-filter will fire events as needed
 	 * to request children
 	 * @param {Map}[extraChildren] - Map from parent node ids to arrays of
-	 * {Items: <nodes>, PagingInfo: {HasMoreItems: boolean, Bookmark}}; these will be added to the tree before
+	 * {Items: OrgUnitNode[], PagingInfo: {HasMoreItems: boolean, Bookmark}}; these will be added to the tree before
 	 * any selections are applied and the parents marked as populated. Useful for adding cached lookups to a dynamic tree.
 	 */
 	constructor({


### PR DESCRIPTION
This PR fixes loading spinner when org unit tree is truncated. It also improves demo code.

* Functional Testing 
  * [x] Test cases
    * Faculty 2 (Id: 9) has a dynamic node on the demo page. It shows loading  spinner when opened
* Security, devops, perf: N/A
* UX and docs
  
FYI @anhill-D2L @hyehayes @johngwilkinson @NicholasHallman @bemailloux @JikaiLong