### PR TITLE
Bump node version used in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
       - name: Install dependencies
         run: npm install
       - name: Visual Diff Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
           persist-credentials: false
       - name: Setup Node
         uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
       - name: Semantic Release
         uses: BrightspaceUI/actions/semantic-release@master
         with:


### PR DESCRIPTION
We are planning to bump the version of Puppeteer used in visual-diff and so this PR is to bump the node version to the current LTS version.