### PR TITLE
Show Clear-button when selection is applied regardless org unit is truncated or forbidden

### DIFF
--- a/test/tree-filter.test.js
+++ b/test/tree-filter.test.js
@@ -705,11 +705,36 @@ describe('d2l-labs-tree-filter', () => {
 
 			const treeSelector = el.shadowRoot.querySelector('d2l-labs-tree-selector');
 			expect(treeSelector.name).to.equal('filter');
+			expect(!!treeSelector.isSelected).to.be.false;
+		});
+
+		it('should render with opener-text-selected if any items outside the tree are selected', async() => {
+			const forbiddenOrgUnitId = 707;
+			const treeWithNoSelections = new Tree({ nodes: [
+				[1, 'Course 1', 3, [3], [], 'none', false],
+				[3, 'Department 1', 2, [5], [1], 'none', false],
+				[5, 'Faculty 1', 7, [6607], [3], 'none', false],
+				[6607, 'Dev', 1, [0], [5], 'none', false]
+			], selectedIds: [forbiddenOrgUnitId], leafTypes: [3] });
+
+			el = await fixture(
+				html`<d2l-labs-tree-filter
+				opener-text="filter"
+				opener-text-selected="filter with selections"
+				.tree="${treeWithNoSelections}"
+			></d2l-labs-tree-filter>`
+			);
+			await el.treeUpdateComplete;
+
+			const treeSelector = el.shadowRoot.querySelector('d2l-labs-tree-selector');
+			expect(treeSelector.name).to.equal('filter with selections');
+			expect(!!treeSelector.isSelected).to.be.true;
 		});
 
 		it('should render with opener-text-selected if any items are selected', () => {
 			const treeSelector = el.shadowRoot.querySelector('d2l-labs-tree-selector');
 			expect(treeSelector.name).to.equal('filter with selections');
+			expect(treeSelector.isSelected).to.be.true;
 		});
 
 		it('should render with opener-text-selected if all items are deselected but initial selections are not reset', async() => {

--- a/tree-filter.js
+++ b/tree-filter.js
@@ -557,14 +557,13 @@ class TreeFilter extends Localizer(MobxLitElement) {
 		// if selections are applied when loading from server but the selected ids were truncated out of the results,
 		// the visible selections in the UI (this.tree.selected) could be empty even though selections are applied.
 		// In that case, we should indicate to the user that selections are applied, even if they can't see them.
-		const openerText = (this.tree.selected.length || (this.tree.initialSelectedIds && this.tree.initialSelectedIds.length))
-			? this.openerTextSelected
-			: this.openerText;
+		const isSelected = (this.tree.selected.length || (this.tree.initialSelectedIds && this.tree.initialSelectedIds.length));
+		const openerText = isSelected ? this.openerTextSelected : this.openerText;
 
 		return html`<d2l-labs-tree-selector
 				name="${openerText}"
 				?search="${this._isSearch}"
-				?selected="${this.tree.selected.length > 0}"
+				?selected="${isSelected}"
 				@d2l-labs-tree-selector-search="${this._onSearch}"
 				@d2l-labs-tree-selector-clear="${this._onClear}"
 			>


### PR DESCRIPTION
[DE46040](https://rally1.rallydev.com/#/?detail=/defect/614623671889&fdp=true): AQD: load url with filter specifying courses current user cannot view is quirky

* Functional Testing 
  * [x] Test cases
    * [x] A user sees Clear-button if selection is applied. A selected org unit can be forbidden or truncated.
* Security, devops, perf: N/A
* UX and docs

* [x] Demo

  
FYI @Brightspace/draco-vis