### PR TITLE
add lit as a dependency (needed for lit-mobx)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@brightspace-ui/core": "^2",
     "@brightspace-ui/intl": "^3.2.0",
     "array-flat-polyfill": "^1.0.1",
+    "lit": "^2",
     "lit-element": "^3",
     "lit-html": "^2",
     "mobx": "^5.15.7"


### PR DESCRIPTION
lit-mobx has a peer dependency on the `"lit"` package specifically. Lit is a wrapper of lit-element and lit-html, so no code is being added. We can remove lit-element and lit-html imports once the paths are changed to reference `lit/` paths directly.