### PR TITLE
Clear button clears the selection for invisible nodes as well

### DIFF
--- a/test/tree-filter.test.js
+++ b/test/tree-filter.test.js
@@ -126,6 +126,7 @@ describe('Tree', () => {
 		it('should clear selection', () => {
 			dynamicTree.clearSelection();
 			expect(dynamicTree.selected).to.be.empty;
+			expect(dynamicTree.initialSelectedIds).to.be.empty;
 		});
 
 		it('should set selected nodes', () => {

--- a/tree-filter.js
+++ b/tree-filter.js
@@ -214,6 +214,9 @@ export class Tree {
 
 	clearSelection() {
 		this._state.clear();
+		// when we hit Clear button we expect that all selection is cleared
+		// including selection in the dynamic tree with invisible selected nodes
+		this.initialSelectedIds = [];
 	}
 
 	selectAll() {
@@ -503,6 +506,7 @@ decorate(Tree, {
 	_bookmarks: observable,
 	_hasMore: observable,
 	_visibilityModifiers: observable,
+	initialSelectedIds: observable,
 	selected: computed,
 	allSelectedCourses: computed,
 	addNodes: action,


### PR DESCRIPTION
Tests:
* Unit test
* E2E test on Adoption dashboard to verify that Clear button disappears right after hitting it even if hidden nodes are selected