### PR TITLE
Tree updates ancestor state if it dynamically loads children that are selected

### DIFF
--- a/demo/demoDataManager.js
+++ b/demo/demoDataManager.js
@@ -47,7 +47,7 @@ export class DemoDataManager extends OuFilterDataManager {
 			nodes: lastSearchResults ? [...orgUnits, ...lastSearchResults] : orgUnits,
 			leafTypes: [COURSE_OFFERING],
 			invisibleTypes: [OU_TYPES.SEM],
-			selectedIds: [1],
+			selectedIds: [1, 21],
 			ancestorIds: [],
 			oldTree: this.orgUnitTree,
 			isDynamic: isOrgUnitsTruncated,

--- a/test/tree-filter.test.js
+++ b/test/tree-filter.test.js
@@ -330,6 +330,25 @@ describe('Tree', () => {
 			assertSetsAreEqual(dynamicTree.getAncestorIds(1), new Set([1, 1001, 1003, 6606]));
 			assertSetsAreEqual(dynamicTree.getAncestorIds(112), new Set([112, 1, 1001, 1003, 12, 6606]));
 		});
+
+		it('should update ancestors state when loaded selected nodes', () => {
+			dynamicTree = new Tree({ nodes: nodes.filter(n => !n.Parents?.includes(1)), selectedIds, leafTypes, invisibleTypes, isDynamic: true });
+			expect(dynamicTree.getState(1)).to.equal('none');
+			expect(dynamicTree.getState(2)).to.equal('none');
+			expect(dynamicTree.getState(3)).to.equal('none');
+			expect(dynamicTree.getState(4)).to.equal('explicit');
+
+			dynamicTree.addNodes(1, [
+				{ Id: 111, Name: 'Course 1 / Semester 1', Type: mockOuTypes.courseOffering, Parents: [1, 11] },
+				{ Id: 112, Name: 'Course 1 / Semester 2', Type: mockOuTypes.courseOffering, Parents: [1, 12] },
+			]);
+
+			expect(dynamicTree.getState(1)).to.equal('indeterminate');
+			expect(dynamicTree.getState(2)).to.equal('none');
+			expect(dynamicTree.getState(3)).to.equal('none');
+			expect(dynamicTree.getState(4)).to.equal('explicit');
+		});
+
 	});
 
 	describe('addTree', () => {

--- a/tree-filter.js
+++ b/tree-filter.js
@@ -168,6 +168,11 @@ export class Tree {
 		}
 		if (this.getState(parentId) === 'explicit') {
 			newChildren.forEach(x => this._state.set(x.Id, 'explicit'));
+		} else {
+			const initialSelectedIdSet = new Set(this.initialSelectedIds);
+			if (newChildren.some(x => initialSelectedIdSet.has(x.Id))) {
+				this._updateSelected(parentId);
+			}
 		}
 
 		// Ancestors may need updating: if one or more of newChildren was already present (due to
@@ -414,7 +419,9 @@ export class Tree {
 		if (state === 'explicit') return [id];
 
 		if (state === 'indeterminate' || this._isRoot(id)) {
-			return this.getChildIds(id).flatMap(childId => this._getSelected(childId));
+			// when this.getChildIds(id) returns null as one of its child id it causes infinite loop
+			const isNotNullOrUndefined = (id) => id !== undefined && id !== null;
+			return this.getChildIds(id).filter(isNotNullOrUndefined).flatMap(childId => this._getSelected(childId));
 		}
 
 		return [];


### PR DESCRIPTION
Tree updates ancestor state if it dynamically loads children that are selected.

Testing:
* unit tests
* e2e test on draco
* demo data test

![update-parent-selection-state](https://user-images.githubusercontent.com/9429561/167076029-20ee9ba5-a808-4c57-bc9a-69a35f238c0e.gif)
