### PR TITLE
The tree search function is configurable

### DIFF
--- a/demo/demoDataManager.js
+++ b/demo/demoDataManager.js
@@ -1,5 +1,5 @@
 import { action, decorate, observable } from 'mobx';
-import { COURSE_OFFERING, Tree } from '../tree-filter';
+import { COURSE_OFFERING, includesSearch, Tree } from '../tree-filter';
 import { OuFilterDataManager } from '../ou-filter';
 // import { createNaryTree } from './util.js';
 
@@ -19,9 +19,10 @@ const OU_TYPES = {
 /* eslint-disable no-console */
 export class DemoDataManager extends OuFilterDataManager {
 
-	constructor() {
+	constructor(searchFn) {
 		super();
 		this._orgUnitTree = new Tree({});
+		this._searchFn = searchFn;
 	}
 
 	loadData() {
@@ -55,7 +56,8 @@ export class DemoDataManager extends OuFilterDataManager {
 			// tree blink out and then come back as they are loaded again
 			extraChildren: isOrgUnitsTruncated ?
 				fetchCachedChildren() || new Map() :
-				null
+				null,
+			searchFn: this._searchFn ? this._searchFn : includesSearch
 		});
 
 		// for perf testing

--- a/demo/ouFilterDemoPage.js
+++ b/demo/ouFilterDemoPage.js
@@ -3,6 +3,7 @@ import '@brightspace-ui/core/components/inputs/input-search.js';
 import { css, html } from 'lit-element/lit-element.js';
 import { DemoDataManager } from './demoDataManager.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
+import { startsWithSearch } from '../tree-filter';
 
 function parseHash(hash) {
 	return hash.substring(1).split(';').reduce((acc, curr) => {
@@ -44,6 +45,10 @@ class OuFilterDemoPage extends MobxLitElement {
 
 		if (hashMap.has('dir')) {
 			document.documentElement.setAttribute('dir', hashMap.get('dir'));
+		}
+
+		if (hashMap.has('search') && hashMap.get('search') === 'startswith') {
+			this.dataManager = new DemoDataManager(startsWithSearch);
 		}
 	}
 

--- a/ou-filter.js
+++ b/ou-filter.js
@@ -93,7 +93,7 @@ class OuFilter extends Localizer(MobxLitElement) {
 	}
 
 	get selected() {
-		return this.shadowRoot?.querySelector('d2l-labs-tree-filter')?.selected || [];
+		return this.dataManager.orgUnitTree.selected;
 	}
 
 	_onChange() {

--- a/test/tree-filter.test.js
+++ b/test/tree-filter.test.js
@@ -1,6 +1,6 @@
 import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { runConstructor } from '@brightspace-ui/core/tools/constructor-test-helper.js';
-import { Tree } from '../tree-filter';
+import { startsWithSearch, Tree } from '../tree-filter';
 
 const mockOuTypes = {
 	organization: 0,
@@ -712,6 +712,16 @@ describe('Tree', () => {
 			it('should return pruned nodes as well', async() => {
 				const tree = new Tree({ nodes: singleCourseOfferingNodes, selectedIds, leafTypes, invisibleTypes, isDynamic: false });
 				expect(tree.getMatchingIds('1')).to.deep.equal([1001, 111, 1]);
+			});
+
+			it('should search nodes that starts with', async() => {
+				const nodes = [
+					...singleCourseOfferingNodes,
+					{ Id: 13, Name: 'New course 2', Type: mockOuTypes.course, Parents: [6606] } // this should not be found
+				];
+				const tree = new Tree({ nodes: nodes, selectedIds, leafTypes, invisibleTypes, isDynamic: false,
+					searchFn: startsWithSearch });
+				expect(tree.getMatchingIds('co')).to.deep.equal([111, 1]);
 			});
 		});
 

--- a/tree-filter.js
+++ b/tree-filter.js
@@ -10,6 +10,12 @@ import { MobxLitElement } from '@adobe/lit-mobx';
 // node array indices
 export const COURSE_OFFERING = 3;
 
+export const includesSearch = (nodeName, searchString) =>
+	nodeName.toLowerCase().includes(searchString.toLowerCase());
+
+export const startsWithSearch = (nodeName, searchString) =>
+	nodeName.toLowerCase().startsWith(searchString.toLowerCase());
+
 /**
  * An object that represents org unit node
  * @typedef {Object} OrgUnitNode
@@ -37,6 +43,7 @@ export class Tree {
 	 * {Items: OrgUnitNode[], PagingInfo: {HasMoreItems: boolean, Bookmark}}; these will be added to the tree before
 	 * any selections are applied and the parents marked as populated. Useful for adding cached lookups to a dynamic tree.
 	 * @param visibilityModifiers - optional kvp where values are functions that map an orgUnitId to a boolean indicating visibility
+	 * @param searchFn - function that filters nodes when a user hit search button. It takes two params nodeName and searchString
 	 */
 	constructor({
 		nodes = [],
@@ -47,7 +54,8 @@ export class Tree {
 		oldTree,
 		isDynamic = false,
 		extraChildren,
-		visibilityModifiers = {}
+		visibilityModifiers = {},
+		searchFn = includesSearch
 	}) {
 		this.leafTypes = leafTypes;
 		this.invisibleTypes = invisibleTypes;
@@ -67,6 +75,7 @@ export class Tree {
 		this._bookmarks = new Map();
 
 		this._visibilityModifiers = visibilityModifiers;
+		this._searchFn = searchFn;
 
 		// fill in children (parents are provided by the caller, and ancestors will be generated on demand)
 		this._updateChildren(this.ids);
@@ -268,7 +277,7 @@ export class Tree {
 	getMatchingIds(searchString) {
 		return this.ids
 			.filter(x => this._isVisible(x))
-			.filter(x => !this._isRoot(x) && this._nameForSort(x).toLowerCase().includes(searchString.toLowerCase()))
+			.filter(x => !this._isRoot(x) && this._searchFn(this._nameForSort(x), searchString))
 			// reverse order by id so the order is consistent and (most likely) newer items are on top
 			.sort((x, y) => y - x);
 	}


### PR DESCRIPTION
Tree has an internal search function that filters nodes by name. It filters using `includes` function. This function should be configurable to match the search algorithm that is used by LMS.

- [ ] E2E Tests
  - [ ] when the search function is `startsWithSearch` then Tree shows only nodes that start with search string (chars case is ignored)
  - [ ] if search function is not provided then `includesSearch` is used. Tree shows node that contain search string

