### PR TITLE
fix: Fix path to fr-on file

### DIFF
--- a/locales/localizer.js
+++ b/locales/localizer.js
@@ -54,7 +54,7 @@ export const Localizer = superclass => class extends LocalizeMixin(superclass) {
 						break;
 					case 'fr-on':
 					case 'fr-ON':
-						translations = await import('./fr-ON.js');
+						translations = await import('./fr-on.js');
 						break;
 					case 'hi':
 						translations = await import('./hi.js');


### PR DESCRIPTION
Looks like there were some `fr-on` changes done a year ago that were never released, so my release token PR caused them to be discovered by BSI. Updating the file path to use the lowercase file name, which matches the actual file.