### PR TITLE
fix: lit dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ci](https://github.com/BrightspaceUILabs/ou-filter/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/BrightspaceUILabs/ou-filter/actions/workflows/ci.yml)
 
-A Lit-element component that renders org unit structure tree. It supports load more and searching functionality.
+A Lit component that renders org unit structure tree. It supports load more and searching functionality.
 
 > Note: this is a ["labs" component](https://daylight.d2l.dev/developing/getting-started/component-tiers/). While functional, these tasks are prerequisites to promotion to BrightspaceUI "official" status:
 >

--- a/demo/ouFilterDemoPage.js
+++ b/demo/ouFilterDemoPage.js
@@ -1,6 +1,6 @@
 import '@brightspace-ui/core/components/inputs/input-search.js';
 
-import { css, html } from 'lit-element/lit-element.js';
+import { css, html } from 'lit';
 import { DemoDataManager } from './demoDataManager.js';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { startsWithSearch } from '../tree-filter';

--- a/ou-filter.js
+++ b/ou-filter.js
@@ -1,4 +1,4 @@
-import { css, html } from 'lit-element/lit-element.js';
+import { css, html } from 'lit';
 import { Localizer } from './locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 import { Tree } from './tree-filter';

--- a/package.json
+++ b/package.json
@@ -54,8 +54,6 @@
     "@brightspace-ui/intl": "^3.2.0",
     "array-flat-polyfill": "^1.0.1",
     "lit": "^2",
-    "lit-element": "^3",
-    "lit-html": "^2",
     "mobx": "^5.15.7"
   }
 }

--- a/test/visual-diff/d2l-labs-ou-filter.visual-diff.html
+++ b/test/visual-diff/d2l-labs-ou-filter.visual-diff.html
@@ -11,7 +11,7 @@
 			/* eslint-disable no-console */
 			import { action, decorate, observable } from 'mobx';
 			import { COURSE_OFFERING, Tree } from '../../tree-filter';
-			import { css, html } from 'lit-element/lit-element.js';
+			import { css, html } from 'lit';
 			import { MobxLitElement } from '@adobe/lit-mobx';
 			import { OuFilterDataManager } from '../../ou-filter';
 

--- a/tree-filter.js
+++ b/tree-filter.js
@@ -3,7 +3,7 @@ import './tree-selector.js';
 
 import 'array-flat-polyfill';
 import { action, computed, decorate, observable } from 'mobx';
-import { css, html } from 'lit-element/lit-element.js';
+import { css, html } from 'lit';
 import { Localizer } from './locales/localizer';
 import { MobxLitElement } from '@adobe/lit-mobx';
 

--- a/tree-selector-node.js
+++ b/tree-selector-node.js
@@ -1,7 +1,7 @@
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/inputs/input-checkbox';
 
-import { css, html, LitElement } from 'lit-element/lit-element.js';
+import { css, html, LitElement } from 'lit';
 import { Localizer } from './locales/localizer';
 import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 

--- a/tree-selector.js
+++ b/tree-selector.js
@@ -5,7 +5,7 @@ import '@brightspace-ui/core/components/dropdown/dropdown-content.js';
 import '@brightspace-ui/core/components/dropdown/dropdown.js';
 import '@brightspace-ui/core/components/inputs/input-search.js';
 
-import { css, html, LitElement, nothing } from 'lit-element/lit-element.js';
+import { css, html, LitElement, nothing } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { Localizer } from './locales/localizer';
 import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles';


### PR DESCRIPTION
This isn't a prerequisite for upgrading to Lit 3 next year, but cleaning up the warnings would be nice. Both `lit-element` and `lit-html` have been rolled into `lit` for quite some time.