### PR TITLE
MAN-3297 Add empty state

### DIFF
--- a/locales/ar.js
+++ b/locales/ar.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "مسح",
 	"treeSelector:searchLabel": "بحث",
 	"treeSelector:loadMoreLabel": "تحميل المزيد",
+	"treeSelector:noSearchResults": "ما من نتائج بحث",
 	"treeSelector:parentLoadMore:ariaLabel": "تحميل المزيد من الوحدات التنظيمية الفرع",
 	"treeSelector:searchLoadMore:ariaLabel": "تحميل المزيد من نتائج البحث",
 	"treeSelector:searchPlaceholder": "البحث...",

--- a/locales/cy.js
+++ b/locales/cy.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Clirio",
 	"treeSelector:searchLabel": "Chwilio",
 	"treeSelector:loadMoreLabel": "Llwytho Mwy",
+	"treeSelector:noSearchResults": "Dim canlyniadau chwilio",
 	"treeSelector:parentLoadMore:ariaLabel": "Llwytho mwy o unedau sefydliad plant",
 	"treeSelector:searchLoadMore:ariaLabel": "Llwytho mwy o ganlyniadau chwilio",
 	"treeSelector:searchPlaceholder": "Chwilio...",

--- a/locales/da.js
+++ b/locales/da.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Ryd",
 	"treeSelector:searchLabel": "Søg",
 	"treeSelector:loadMoreLabel": "Indlæs flere",
+	"treeSelector:noSearchResults": "Ingen søgeresultater",
 	"treeSelector:parentLoadMore:ariaLabel": "Indlæs flere underordnede organisationsenheder",
 	"treeSelector:searchLoadMore:ariaLabel": "Indlæs flere søgeresultater",
 	"treeSelector:searchPlaceholder": "Søg ...",

--- a/locales/de.js
+++ b/locales/de.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Löschen",
 	"treeSelector:searchLabel": "Suchen",
 	"treeSelector:loadMoreLabel": "Mehr laden",
+	"treeSelector:noSearchResults": "Kein Suchergebnis",
 	"treeSelector:parentLoadMore:ariaLabel": "Weitere untergeordnete Organisationseinheiten werden geladen.",
 	"treeSelector:searchLoadMore:ariaLabel": "Weitere Suchergebnisse werden geladen.",
 	"treeSelector:searchPlaceholder": "Suchen...",

--- a/locales/en-gb.js
+++ b/locales/en-gb.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Clear",
 	"treeSelector:searchLabel": "Search",
 	"treeSelector:loadMoreLabel": "Load More",
+	"treeSelector:noSearchResults": "No search results",
 	"treeSelector:parentLoadMore:ariaLabel": "Load more child org units",
 	"treeSelector:searchLoadMore:ariaLabel": "Load more search results",
 	"treeSelector:searchPlaceholder": "Search...",

--- a/locales/en.js
+++ b/locales/en.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Clear",
 	"treeSelector:searchLabel": "Search",
 	"treeSelector:loadMoreLabel": "Load More",
+	"treeSelector:noSearchResults": "No search results",
 	"treeSelector:parentLoadMore:ariaLabel": "Load more child org units",
 	"treeSelector:searchLoadMore:ariaLabel": "Load more search results",
 	"treeSelector:searchPlaceholder": "Search...",

--- a/locales/es-es.js
+++ b/locales/es-es.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Borrar",
 	"treeSelector:searchLabel": "Buscar",
 	"treeSelector:loadMoreLabel": "Cargar más",
+	"treeSelector:noSearchResults": "No hay resultados de búsqueda",
 	"treeSelector:parentLoadMore:ariaLabel": "Cargar más unidades de organización secundarias",
 	"treeSelector:searchLoadMore:ariaLabel": "Cargar más resultados de búsqueda",
 	"treeSelector:searchPlaceholder": "Buscar…",

--- a/locales/es.js
+++ b/locales/es.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Borrar",
 	"treeSelector:searchLabel": "Buscar",
 	"treeSelector:loadMoreLabel": "Cargar más",
+	"treeSelector:noSearchResults": "No se encontraron resultados de búsqueda",
 	"treeSelector:parentLoadMore:ariaLabel": "Cargar más unidades de organización secundarias",
 	"treeSelector:searchLoadMore:ariaLabel": "Cargar más resultados de búsqueda",
 	"treeSelector:searchPlaceholder": "Buscar…",

--- a/locales/fr-fr.js
+++ b/locales/fr-fr.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Effacer",
 	"treeSelector:searchLabel": "Rechercher",
 	"treeSelector:loadMoreLabel": "Télécharger plus",
+	"treeSelector:noSearchResults": "Aucun résultat de recherche",
 	"treeSelector:parentLoadMore:ariaLabel": "Charger plus d’unités organisationnelles secondaires",
 	"treeSelector:searchLoadMore:ariaLabel": "Charger plus de résultats de recherche",
 	"treeSelector:searchPlaceholder": "Rechercher...",

--- a/locales/fr-on.js
+++ b/locales/fr-on.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Effacer",
 	"treeSelector:searchLabel": "Rechercher",
 	"treeSelector:loadMoreLabel": "En télécharger plus",
+	"treeSelector:noSearchResults": "Aucun résultat de recherche",
 	"treeSelector:parentLoadMore:ariaLabel": "Charger plus d'unités organisationnelles enfants",
 	"treeSelector:searchLoadMore:ariaLabel": "Charger plus de résultats de la recherche",
 	"treeSelector:searchPlaceholder": "Recherche en cours…",

--- a/locales/fr.js
+++ b/locales/fr.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Effacer",
 	"treeSelector:searchLabel": "Rechercher",
 	"treeSelector:loadMoreLabel": "En voir plus",
+	"treeSelector:noSearchResults": "Aucun résultat de recherche",
 	"treeSelector:parentLoadMore:ariaLabel": "Charger plus d’unités organisationnelles enfants",
 	"treeSelector:searchLoadMore:ariaLabel": "Charger plus de résultats de la recherche",
 	"treeSelector:searchPlaceholder": "Recherche…",

--- a/locales/hi.js
+++ b/locales/hi.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "साफ़ करें",
 	"treeSelector:searchLabel": "खोजें",
 	"treeSelector:loadMoreLabel": "अधिक लोड करें",
+	"treeSelector:noSearchResults": "कोई खोज परिणाम नहीं",
 	"treeSelector:parentLoadMore:ariaLabel": "और बाल संगठन इकाइयाँ लोड करें",
 	"treeSelector:searchLoadMore:ariaLabel": "और खोज परिणामों को लोड करें",
 	"treeSelector:searchPlaceholder": "खोजें...",

--- a/locales/ja.js
+++ b/locales/ja.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "クリア",
 	"treeSelector:searchLabel": "検索",
 	"treeSelector:loadMoreLabel": "さらに読み込む",
+	"treeSelector:noSearchResults": "検索結果なし",
 	"treeSelector:parentLoadMore:ariaLabel": "子組織単位をさらに読み込む",
 	"treeSelector:searchLoadMore:ariaLabel": "検索結果をさらに読み込む",
 	"treeSelector:searchPlaceholder": "検索...",

--- a/locales/ko.js
+++ b/locales/ko.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "지우기",
 	"treeSelector:searchLabel": "검색",
 	"treeSelector:loadMoreLabel": "더 많이 로드",
+	"treeSelector:noSearchResults": "검색 결과 없음",
 	"treeSelector:parentLoadMore:ariaLabel": "더 많은 하위 구성 단위 로드",
 	"treeSelector:searchLoadMore:ariaLabel": "더 많은 검색 결과 로드",
 	"treeSelector:searchPlaceholder": "검색...",

--- a/locales/nl.js
+++ b/locales/nl.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Wissen",
 	"treeSelector:searchLabel": "Zoeken",
 	"treeSelector:loadMoreLabel": "Meer laden",
+	"treeSelector:noSearchResults": "Geen zoekresultaten",
 	"treeSelector:parentLoadMore:ariaLabel": "Meer onderliggende organisatie-eenheden laden",
 	"treeSelector:searchLoadMore:ariaLabel": "Meer zoekresultaten laden",
 	"treeSelector:searchPlaceholder": "Zoeken...",

--- a/locales/pt.js
+++ b/locales/pt.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Limpar",
 	"treeSelector:searchLabel": "Pesquisar",
 	"treeSelector:loadMoreLabel": "Carregar mais",
+	"treeSelector:noSearchResults": "Sem resultados para a pesquisa",
 	"treeSelector:parentLoadMore:ariaLabel": "Carregar mais unidades organizacionais secundárias",
 	"treeSelector:searchLoadMore:ariaLabel": "Carregar mais resultados de pesquisa",
 	"treeSelector:searchPlaceholder": "Pesquisar...",

--- a/locales/sv.js
+++ b/locales/sv.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Rensa",
 	"treeSelector:searchLabel": "Sökning",
 	"treeSelector:loadMoreLabel": "Ladda mer",
+	"treeSelector:noSearchResults": "Inga sökresultat",
 	"treeSelector:parentLoadMore:ariaLabel": "Läs in fler underordnade organisationsenheter",
 	"treeSelector:searchLoadMore:ariaLabel": "Läs in fler sökresultat",
 	"treeSelector:searchPlaceholder": "Sök ...",

--- a/locales/tr.js
+++ b/locales/tr.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "Temizle",
 	"treeSelector:searchLabel": "Arama",
 	"treeSelector:loadMoreLabel": "Daha Fazla Yükle",
+	"treeSelector:noSearchResults": "Arama sonucu yok",
 	"treeSelector:parentLoadMore:ariaLabel": "Daha fazla alt org birimi yükle",
 	"treeSelector:searchLoadMore:ariaLabel": "Daha fazla arama sonucu yükle",
 	"treeSelector:searchPlaceholder": "Ara...",

--- a/locales/zh-tw.js
+++ b/locales/zh-tw.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "清除",
 	"treeSelector:searchLabel": "搜尋",
 	"treeSelector:loadMoreLabel": "載入更多",
+	"treeSelector:noSearchResults": "無搜尋結果",
 	"treeSelector:parentLoadMore:ariaLabel": "載入組織子單位",
 	"treeSelector:searchLoadMore:ariaLabel": "載入更多搜尋結果",
 	"treeSelector:searchPlaceholder": "搜尋...",

--- a/locales/zh.js
+++ b/locales/zh.js
@@ -12,6 +12,7 @@ export default {
 	"treeSelector:clearLabel": "清除",
 	"treeSelector:searchLabel": "搜索",
 	"treeSelector:loadMoreLabel": "加载更多",
+	"treeSelector:noSearchResults": "无搜索结果",
 	"treeSelector:parentLoadMore:ariaLabel": "加载更多子组织单位",
 	"treeSelector:searchLoadMore:ariaLabel": "加载更多搜索结果",
 	"treeSelector:searchPlaceholder": "搜索...",

--- a/test/ou-filter.vdiff.js
+++ b/test/ou-filter.vdiff.js
@@ -72,6 +72,9 @@ async function expandDepartment1Node(elem) {
 	sendKeysElem(openButton, 'press', 'Enter');
 	await oneEvent(elem, 'd2l-dropdown-open');
 
+	// Prevents test flake that sometimes occurs when waiting for the dropdown to open and render
+	await new Promise(resolve => setTimeout(resolve, 200));
+
 	// expand Faculty 1
 	const faculty1Node = treeSelector.querySelector('d2l-labs-tree-selector-node[name="Faculty 1 (Id: 5)"]');
 	await sendKeysElem(

--- a/test/tree-filter.test.js
+++ b/test/tree-filter.test.js
@@ -1022,6 +1022,16 @@ describe('d2l-labs-tree-filter', () => {
 			expect(resultNodes.length).to.equal(1);
 			expect([...resultNodes].map(x => x.dataId).sort()).to.deep.equal([9876]);
 		});
+
+		it('should render an empty state when there are no results', async() => {
+			el.searchString = 'asdf';
+			el.addSearchResults([]);
+			await el.treeUpdateComplete;
+
+			const resultNodes = el.shadowRoot.querySelectorAll('d2l-empty-state-simple[slot="search-results"]');
+			expect(resultNodes.length).to.equal(1);
+			expect(resultNodes[0].description).to.equal('No search results');
+		});
 	});
 
 	describe('events', () => {

--- a/tree-filter.js
+++ b/tree-filter.js
@@ -1,3 +1,4 @@
+import '@brightspace-ui/core/components/empty-state/empty-state-simple.js';
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 import './tree-selector.js';
 
@@ -817,11 +818,13 @@ class TreeFilter extends Localizer(MobxLitElement) {
 	}
 
 	_renderSearchResults() {
-		if (!this._isSearch) return nothing;
+		if (!this._isSearch || this._isLoadingSearch) return nothing;
 
-		return this.tree
-			.getMatchingIds(this.searchString)
-			.map(id => {
+		const searchResults = this.tree
+			.getMatchingIds(this.searchString);
+
+		if (searchResults.length > 0) {
+			return searchResults.map(id => {
 				const orgUnitName = this.tree.getName(id);
 				const state = this.tree.getState(id);
 				return html`<d2l-labs-tree-selector-node slot="search-results"
@@ -832,6 +835,13 @@ class TreeFilter extends Localizer(MobxLitElement) {
 				>
 				</d2l-labs-tree-selector-node>`;
 			});
+		}
+
+		return html`<d2l-empty-state-simple
+			slot="search-results"
+			description="${this.localize('treeSelector:noSearchResults')}"
+		>
+		</d2l-empty-state-simple>`;
 	}
 
 	_requestChildren(id, bookmark) {


### PR DESCRIPTION
Discovered this while doing work for this story - just adding in a `d2l-empty-state-simple` here when there are no results, and using the langterms from the core filter component (`components.filter.searchResults`) as this will be needed in 24.08.

https://desire2learn.atlassian.net/browse/MAN-3297 (semi-related, in that I discovered this while working on this story)