### PR TITLE
fix: Clear selection as well when resetting the search

### DIFF
--- a/ou-filter.js
+++ b/ou-filter.js
@@ -101,8 +101,8 @@ class OuFilter extends Localizer(MobxLitElement) {
 			</d2l-labs-tree-filter>`;
 	}
 
-	clearSearch() {
-		this.shadowRoot.querySelector('d2l-labs-tree-filter').clearSearch();
+	clearSearchAndSelection() {
+		this.shadowRoot.querySelector('d2l-labs-tree-filter').clearSearchAndSelection();
 	}
 
 	_onChange() {

--- a/tree-filter.js
+++ b/tree-filter.js
@@ -665,8 +665,8 @@ class TreeFilter extends Localizer(MobxLitElement) {
 		this._isLoadingSearch = false;
 	}
 
-	clearSearch() {
-		this.shadowRoot.querySelector('d2l-labs-tree-selector').clearSearch();
+	clearSearchAndSelection() {
+		this.shadowRoot.querySelector('d2l-labs-tree-selector').clearSearchAndSelection();
 	}
 
 	async resize() {

--- a/tree-selector.js
+++ b/tree-selector.js
@@ -132,13 +132,15 @@ class TreeSelector extends Localizer(LitElement) {
 		`;
 	}
 
-	clearSearch() {
+	clearSearchAndSelection() {
 		this.shadowRoot.querySelector('d2l-input-search').value = '';
 		this._onSearch({
 			detail: {
 				value: ''
 			}
 		});
+
+		this._onClear();
 	}
 
 	async resize() {


### PR DESCRIPTION
Need to reset the selected org units if there were any as well when clearing the search field/results. Can do this pretty simply by just calling `onClear`