### PR TITLE
NTNGL-4056: Ensure children are requested on open

### DIFF
--- a/tree-filter.js
+++ b/tree-filter.js
@@ -755,17 +755,20 @@ class TreeFilter extends Localizer(MobxLitElement) {
 	_renderChildren(id, parentName, indentLevel = 0) {
 		parentName = parentName || this.localize('treeFilter:nodeName:root');
 
-		if (id === undefined || this.tree.getChildIdsForDisplay(id).length === 0) {
-			return html`<d2l-empty-state-simple
-				slot="tree"
-				description="${this.localize('treeSelector:noFiltersAvailable')}"
-			>
-			</d2l-empty-state-simple>`;
+		const emptyState = html`<d2l-empty-state-simple
+			slot="tree"
+			description="${this.localize('treeSelector:noFiltersAvailable')}"
+		></d2l-empty-state-simple>`;
+
+		if (id === undefined) {
+			return emptyState;
 		}
 
 		if (!this.tree.isPopulated(id)) {
 			// request children; in the meantime we can render whatever we have
 			this._requestChildren(id);
+		} else if (this.tree.getChildIdsForDisplay(id).length === 0) {
+			return emptyState;
 		}
 
 		return [


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/NTNGL-4056
Logic fix for https://github.com/BrightspaceUILabs/ou-filter/pull/83

Before | After
-|-
![image](https://github.com/user-attachments/assets/2c158a93-50cc-4d0a-85e4-63b755f22faf)|![image](https://github.com/user-attachments/assets/9f802160-587d-41f9-b9f3-a63d4db0ed5e)